### PR TITLE
Update for 2.7+ logs, forum_read issue, enabling query date limits

### DIFF
--- a/indicator/forum/indicator.class.php
+++ b/indicator/forum/indicator.class.php
@@ -137,6 +137,23 @@ class indicator_forum extends indicator {
                 continue;
             }
 
+            // Add missing data if necessary.
+            if (empty($this->rawdata->posts[$userid]['total'])) {
+                $this->rawdata->posts[$userid]['total'] = 0;
+            }   
+
+            if (empty($this->rawdata->posts[$userid]['replies'])) {
+                $this->rawdata->posts[$userid]['replies'] = 0;
+            }   
+
+            if (empty($this->rawdata->posts[$userid]['new'])) {
+                $this->rawdata->posts[$userid]['new'] = 0;
+            }   
+
+            if (empty($this->rawdata->posts[$userid]['read'])) {
+                $this->rawdata->posts[$userid]['read'] = 0;
+            }   
+
             $local_risk = $this->calculate('totalposts', $this->rawdata->posts[$userid]['total']);
             $risk_contribution = $local_risk * $this->config['w_totalposts'];
             $reason = new stdClass();

--- a/indicator/forum/indicator.class.php
+++ b/indicator/forum/indicator.class.php
@@ -80,7 +80,8 @@ class indicator_forum extends indicator {
             }
             $postrecs->close();
         }
-
+		
+		// try fetching data from forum_read table first
         $sql = "SELECT *
                 FROM {forum_read} fr
                 JOIN {forum} f ON (f.id = fr.forumid)
@@ -89,7 +90,35 @@ class indicator_forum extends indicator {
         $params['courseid'] = $this->courseid;
         $params['startdate'] = $startdate;
         $params['enddate'] = $enddate;
-        if ($readposts = $DB->get_recordset_sql($sql, $params)) {
+		$readposts = $DB->get_recordset_sql($sql, $params);
+		// check if there is any data in forum_read table
+		if (!$readposts->valid()) {
+			// if not, then fetch data from the logs
+			try {
+				// try fetch from both post v2.7 logstore and legacy log
+				$sql = "SELECT c.id, c.userid
+						FROM (
+							SELECT id, userid, timecreated AS time, courseid AS course
+							FROM {logstore_standard_log}
+							WHERE target = 'discussion' AND action = 'viewed'
+							UNION
+							SELECT id, userid, time, course
+							FROM {log}
+							WHERE module = 'forum' AND action = 'view discussion'
+						) c 
+						WHERE c.course = :courseid AND c.time >= :startdate AND c.time <= :enddate";
+				$readposts = $DB->get_recordset_sql($sql, $params);
+			} catch (Exception $e) {
+				// if error thrown, could be missing logstore_standard_log table, so try legacy only
+				$sql = "SELECT id, userid
+						FROM {log}
+						WHERE course = :courseid AND time >= :startdate AND time <= :enddate
+							AND module = 'forum' AND action = 'view discussion'";
+				$readposts = $DB->get_recordset_sql($sql, $params);
+			}
+		}
+		
+        if ($readposts) {
             foreach ($readposts as $read) {
                 if (!isset($posts[$read->userid])) {
                     $posts[$read->userid]['read'] = 0;

--- a/indicator/indicator.class.php
+++ b/indicator/indicator.class.php
@@ -112,7 +112,7 @@ abstract class indicator {
     }
 
     private function get_risk_for_users($userids, $startdate, $enddate) {
-        global $DB;
+        global $DB, $COURSE;
 
         if (empty($userids)) {
             return array();
@@ -121,21 +121,24 @@ abstract class indicator {
         }
 		
 		// get query limit settings
-        $querystartdatetime = get_config('engagement', 'querystartdatetime');
-		$queryenddatetime = get_config('engagement', 'queryenddatetime');
-		$queryspecifydatetime = get_config('engagement', 'queryspecifydatetime');
+		$settingsnames = array('queryspecifydatetime', 'querystartdatetime', 'queryenddatetime');
+		$querysettings = new stdClass();
+		foreach ($settingsnames as $name) {
+			$tempvar = $DB->get_record_sql("SELECT * FROM {report_engagement} WHERE course = $COURSE->id AND indicator = '$name'");
+			$querysettings->{"$name"} = $tempvar->configdata;
+		}
 		// set startdate if necessary
         if ($startdate == null) {
-			if ($querystartdatetime && $queryspecifydatetime) {
-				$this->startdate = $querystartdatetime;
+			if ($querysettings->querystartdatetime && $querysettings->queryspecifydatetime) {
+				$this->startdate = $querysettings->querystartdatetime;
 			} else {
 				$this->startdate = $DB->get_field('course', 'startdate', array('id' => $this->courseid));
 			}
         }
 		// set enddate if necessary
         if ($enddate == null) {
-			if ($queryenddatetime && $queryspecifydatetime) {
-				$this->enddate = $queryenddatetime;
+			if ($querysettings->queryenddatetime && $querysettings->queryspecifydatetime) {
+				$this->enddate = $querysettings->queryenddatetime;
 			} else {
 				$this->enddate = time();
 			}

--- a/indicator/indicator.class.php
+++ b/indicator/indicator.class.php
@@ -110,7 +110,7 @@ abstract class indicator {
 
         return self::get_risk_for_users($users, $startdate, $enddate);
     }
-
+	
     private function get_risk_for_users($userids, $startdate, $enddate) {
         global $DB, $COURSE;
 
@@ -147,15 +147,14 @@ abstract class indicator {
         $this->cachettl = get_config('engagement', 'cachettl');
 		$this->cachettl = 0; // hack to disable cache
         // If caching is enabled and cache data exists, use that, otherwise call function to fetch live.
-        if ($this->cachettl && $rawdata = $this->get_cache()) { // TODO: Try to fetch from cache here.
+        /*if ($this->cachettl && $rawdata = $this->get_cache()) { // TODO: Try to fetch from cache here.
             $this->rawdata = $rawdata;
-        } else {
+        } else {*/
             $this->rawdata = $this->get_rawdata($this->startdate, $this->enddate);
             if ($this->cachettl) {
                 $this->set_cache();
             }
-        }
-
+        /*}*/ // disable use of cache
         return $this->calculate_risks($userids);
     }
 

--- a/indicator/indicator.class.php
+++ b/indicator/indicator.class.php
@@ -119,12 +119,35 @@ abstract class indicator {
         } else if (is_int($userids)) {
             $userids = array($userids);
         }
+<<<<<<< HEAD
+		
+		// get query limit settings
+        $querystartdatetime = get_config('engagement', 'querystartdatetime');
+		$queryenddatetime = get_config('engagement', 'queryenddatetime');
+		$queryspecifydatetime = get_config('engagement', 'queryspecifydatetime');
+		// set startdate if necessary
+        if ($startdate == null) {
+			if ($querystartdatetime && $queryspecifydatetime) {
+				$this->startdate = $querystartdatetime;
+			} else {
+				$this->startdate = $DB->get_field('course', 'startdate', array('id' => $this->courseid));
+			}
+        }
+		// set enddate if necessary
+        if ($enddate == null) {
+			if ($queryenddatetime && $queryspecifydatetime) {
+				$this->enddate = $queryenddatetime;
+			} else {
+				$this->enddate = time();
+			}
+=======
 
         if ($startdate == null) {
             $this->startdate = $DB->get_field('course', 'startdate', array('id' => $this->courseid));
         }
         if ($enddate == null) {
             $this->enddate = time();
+>>>>>>> 6fad683298d296c5cfe2d4c6d61b411ffabc85c4
         }
 
         $this->cachettl = get_config('engagement', 'cachettl');

--- a/indicator/indicator.class.php
+++ b/indicator/indicator.class.php
@@ -145,6 +145,7 @@ abstract class indicator {
 		}
 
         $this->cachettl = get_config('engagement', 'cachettl');
+		$this->cachettl = 0; // hack to disable cache
         // If caching is enabled and cache data exists, use that, otherwise call function to fetch live.
         if ($this->cachettl && $rawdata = $this->get_cache()) { // TODO: Try to fetch from cache here.
             $this->rawdata = $rawdata;

--- a/indicator/indicator.class.php
+++ b/indicator/indicator.class.php
@@ -30,6 +30,7 @@ abstract class indicator {
     protected $courseid;
     protected $instance;
     protected $rawdata;
+	protected $userarray;
 
     public function __construct($courseid, array $_config = array()) {
         global $DB;
@@ -107,9 +108,18 @@ abstract class indicator {
             }
         }
         $users = array_keys($users);
+		$this->userarray = $users;
 
         return self::get_risk_for_users($users, $startdate, $enddate);
     }
+
+	public function get_course_rawdata($startdate = null, $enddate = null) {
+		return $this->rawdata;
+	}
+	
+	public function get_course_users() {
+		return $this->userarray;
+	}
 	
     private function get_risk_for_users($userids, $startdate, $enddate) {
         global $DB, $COURSE;
@@ -155,6 +165,7 @@ abstract class indicator {
                 $this->set_cache();
             }
         /*}*/ // disable use of cache
+
         return $this->calculate_risks($userids);
     }
 

--- a/indicator/indicator.class.php
+++ b/indicator/indicator.class.php
@@ -119,7 +119,6 @@ abstract class indicator {
         } else if (is_int($userids)) {
             $userids = array($userids);
         }
-<<<<<<< HEAD
 		
 		// get query limit settings
         $querystartdatetime = get_config('engagement', 'querystartdatetime');
@@ -140,15 +139,7 @@ abstract class indicator {
 			} else {
 				$this->enddate = time();
 			}
-=======
-
-        if ($startdate == null) {
-            $this->startdate = $DB->get_field('course', 'startdate', array('id' => $this->courseid));
-        }
-        if ($enddate == null) {
-            $this->enddate = time();
->>>>>>> 6fad683298d296c5cfe2d4c6d61b411ffabc85c4
-        }
+		}
 
         $this->cachettl = get_config('engagement', 'cachettl');
         // If caching is enabled and cache data exists, use that, otherwise call function to fetch live.

--- a/indicator/login/indicator.class.php
+++ b/indicator/login/indicator.class.php
@@ -45,11 +45,35 @@ class indicator_login extends indicator {
         $params['courseid'] = $this->courseid;
         $params['startdate'] = $startdate;
         $params['enddate'] = $enddate;
-        $sql = "SELECT id, userid, time
-                FROM {log}
-                WHERE course = :courseid AND time >= :startdate AND time <= :enddate
-                ORDER BY time ASC";
-        if ($logs = $DB->get_recordset_sql($sql, $params)) {
+		// attempt to query both v2.7 logstore_standard_log table as well as legacy log table
+		try {
+			// query combination of logstore_standard_log and legacy log tables
+			$sqllog27 = "SELECT c.id, c.userid, c.time
+							FROM 
+							(
+								SELECT id, userid, time
+								FROM {log}
+								WHERE course = :courseid AND time >= :startdate AND time <= :enddate
+								UNION
+								SELECT id, userid, timecreated AS time
+								FROM {logstore_standard_log}
+								WHERE courseid = :courseidls AND timecreated >= :startdatels AND timecreated <= :enddatels
+							) c ORDER BY time ASC";
+			// additional params
+			$params['courseidls'] = $this->courseid;
+			$params['startdatels'] = $startdate;
+			$params['enddatels'] = $enddate;
+			// run query
+			$logs = $DB->get_recordset_sql($sqllog27, $params);
+		} catch (Exception $e) {
+			// otherwise query legacy only
+			$sql = "SELECT id, userid, time
+					FROM {log}
+					WHERE course = :courseid AND time >= :startdate AND time <= :enddate
+					ORDER BY time ASC";
+			$logs = $DB->get_recordset_sql($sql, $params);
+		}
+        if ($logs) {
             // Need to calculate sessions, sessions are defined by time between consequtive logs not exceeding setting.
             foreach ($logs as $log) {
                 $increment = false;

--- a/indicator/login/indicator.class.php
+++ b/indicator/login/indicator.class.php
@@ -51,18 +51,14 @@ class indicator_login extends indicator {
 			$sqllog27 = "SELECT c.id, c.userid, c.time
 							FROM 
 							(
-								SELECT id, userid, time
+								SELECT id, userid, time, course
 								FROM {log}
-								WHERE course = :courseid AND time >= :startdate AND time <= :enddate
 								UNION
-								SELECT id, userid, timecreated AS time
+								SELECT id, userid, timecreated AS time, courseid AS course
 								FROM {logstore_standard_log}
-								WHERE courseid = :courseidls AND timecreated >= :startdatels AND timecreated <= :enddatels
-							) c ORDER BY time ASC";
-			// additional params
-			$params['courseidls'] = $this->courseid;
-			$params['startdatels'] = $startdate;
-			$params['enddatels'] = $enddate;
+							) c 
+							WHERE c.course = :courseid AND c.time >= :startdate AND c.time <= :enddate
+							ORDER BY c.time ASC";
 			// run query
 			$logs = $DB->get_recordset_sql($sqllog27, $params);
 		} catch (Exception $e) {


### PR DESCRIPTION
Changes to forum indicator:
* Added ability to read forum view discussion activity from logs (both legacy and 2.7+) because forum_read contains no data on some installations

Changes to login indicator:
* Added support for logstore_standard_log in Moodle 2.7+

Changes to indicator base class:
* Enabling the startdate and enddate query limits (we wanted to be able to limit the query to particular weeks of semester)
   * This is linked to changes in moodle-report_engagement