### PR TITLE
Assessment risk calculator sumgrades to only score included assessments

### DIFF
--- a/indicator/assessment/indicator.class.php
+++ b/indicator/assessment/indicator.class.php
@@ -29,6 +29,9 @@ require_once(dirname(__FILE__).'/../indicator.class.php');
 require_once($CFG->dirroot . '/mod/quiz/lib.php');
 
 class indicator_assessment extends indicator {
+	
+	private $sumgrades = 0;
+	
     /**
      * get_risk_for_users_users
      *
@@ -45,17 +48,16 @@ class indicator_assessment extends indicator {
         $this->calculator = new assessment_risk_calculator;
 
         $rawdata = new stdClass();
-        $rawdata->sumgrades = 0;
 
-        $activities = array();
+        $activities = array(); //id, itemtype, itemmodule, iteminstance, grademax
         $grade_items = $DB->get_records_sql("
-            SELECT      id, itemtype, itemmodule, iteminstance, grademax
+            SELECT      *
             FROM        {grade_items}
             WHERE       courseid=?
         ", array($this->courseid));
         foreach ($grade_items as $gi) {
             if (in_array($gi->itemtype, array('mod', 'manual'))) {
-                $rawdata->sumgrades += $gi->grademax;
+                // $rawdata->sumgrades += $gi->grademax; // calculate this in the add_* methods
                 if ($gi->itemtype == 'mod') {
                     $activities[$gi->itemmodule][] = $gi;
                 }
@@ -77,6 +79,7 @@ class indicator_assessment extends indicator {
         }
 
         $rawdata->assessments = $this->calculator->as_object();
+		$rawdata->sumgrades = $this->sumgrades;
         return $rawdata;
     }
 
@@ -119,6 +122,8 @@ class indicator_assessment extends indicator {
         foreach ($assignments as $a) {
             $grademax = $assignment_ids[$a->id]->grademax;
             $this->calculator->add_assessment($grademax, $submissions[$a->id], get_string('modulename', 'assign').": {$a->name}");
+			// only add grademax for this assignment into sumgrades if submissions are allowed
+			$this->sumgrades += $grademax;
         }
     }
 
@@ -153,6 +158,8 @@ class indicator_assessment extends indicator {
         foreach ($assignments as $a) {
             $grademax = $assignment_ids[$a->id]->grademax;
             $this->calculator->add_assessment($grademax, $submissions[$a->id], get_string('modulename', 'assignment').": {$a->name}");
+			// only add grademax for this assignment into sumgrades if submissions are allowed
+			$this->sumgrades += $grademax;
         }
     }
 
@@ -235,6 +242,8 @@ class indicator_assessment extends indicator {
         }
         foreach ($quizzes as $q) {
             $grademax = $quiz_ids[$q->id]->grademax;
+			// add grademax to sumgrades
+			$this->sumgrades += $grademax;
             // Process user overrides for this quiz.
 
             $this->calculator->add_assessment($grademax, $submissions[$q->id], get_string('modulename', 'quiz').': ' . $q->name);

--- a/indicator/assessment/indicator.class.php
+++ b/indicator/assessment/indicator.class.php
@@ -303,7 +303,7 @@ class assessment_risk_calculator {
                                      ($settings['overduemaximumdays'] - $settings['overduegracedays']);
                 $days_late_weighting = max(0, min(1, $days_late_weighting));
                 $assessment_value_weighting = $a->maxscore / $total_assessment_value;
-                $reason->assessmentweighting = intval($assessment_value_weighting*100) . '%';
+                $reason->assessmentweighting = number_format($assessment_value_weighting*100, 1) . '%';
                 if (isset($a->submissions[$uid]['submitted'])) {
                     // Assessment was submitted.
                     $attime = date("d-m-Y H:i", $submittime);
@@ -314,8 +314,8 @@ class assessment_risk_calculator {
                     $local_risk = $days_late_weighting * $settings['overduesubmittedweighting'];
                     $risk_contribution = $assessment_value_weighting * $local_risk;
                     $risk += $risk_contribution;
-                    $reason->riskcontribution = intval($risk_contribution*100).'%';
-                    $reason->localrisk = intval($local_risk*100).'%';
+                    $reason->riskcontribution = number_format($risk_contribution*100, 1).'%';
+                    $reason->localrisk = number_format($local_risk*100, 1).'%';
                     $mr = intval($settings['overduesubmittedweighting'] * 100);
                     $reason->logic = "0% risk before grace period ($gp days) ... $mr% risk after max days ($md).";
                 } else {
@@ -323,8 +323,8 @@ class assessment_risk_calculator {
                     $local_risk = $days_late_weighting * $settings['overduenotsubmittedweighting'];
                     $risk_contribution = $assessment_value_weighting * $local_risk;
                     $risk += $risk_contribution;
-                    $reason->riskcontribution = intval($risk_contribution*100).'%';
-                    $reason->localrisk = intval($local_risk*100).'%';
+                    $reason->riskcontribution = number_format($risk_contribution*100, 1).'%';
+                    $reason->localrisk = number_format($local_risk*100, 1).'%';
                     $mr = intval($settings['overduenotsubmittedweighting'] * 100);
                     $reason->logic = "0% risk before grace period ($gp days) ... $mr% risk after max days ($md).";
                 }

--- a/indicator/forum/indicator.class.php
+++ b/indicator/forum/indicator.class.php
@@ -93,7 +93,6 @@ class indicator_forum extends indicator {
 		$readposts = $DB->get_recordset_sql($sql, $params);
 		// Check if there is any data in forum_read table
 		if (!$readposts->valid()) {
-			var_dump($readposts->valid());
 			// If not, fetch data from logs
 			// set the sql based on log reader(s) available
 			$sql = array();

--- a/indicator/forum/indicator.class.php
+++ b/indicator/forum/indicator.class.php
@@ -111,7 +111,7 @@ class indicator_forum extends indicator {
 			}
 			$query_sql = 'SELECT c.id, c.userid FROM (' . implode(' UNION ', $sql) . ') c WHERE c.course = :courseid AND c.time >= :startdate AND c.time <= :enddate';
 			// read logs
-			$logs = $DB->get_recordset_sql($query_sql, $params);
+			$readposts = $DB->get_recordset_sql($query_sql, $params);
 		}
         if ($readposts) {
             foreach ($readposts as $read) {

--- a/indicator/forum/indicator.class.php
+++ b/indicator/forum/indicator.class.php
@@ -80,7 +80,8 @@ class indicator_forum extends indicator {
             }
             $postrecs->close();
         }
-
+		
+		// Try fetching from forum_read table first
         $sql = "SELECT *
                 FROM {forum_read} fr
                 JOIN {forum} f ON (f.id = fr.forumid)
@@ -89,7 +90,31 @@ class indicator_forum extends indicator {
         $params['courseid'] = $this->courseid;
         $params['startdate'] = $startdate;
         $params['enddate'] = $enddate;
-        if ($readposts = $DB->get_recordset_sql($sql, $params)) {
+		$readposts = $DB->get_recordset_sql($sql, $params);
+		// Check if there is any data in forum_read table
+		if (!$readposts->valid()) {
+			var_dump($readposts->valid());
+			// If not, fetch data from logs
+			// set the sql based on log reader(s) available
+			$sql = array();
+			$logmanager = get_log_manager();
+			$readers = $logmanager->get_readers(); 
+			foreach ($readers as $reader) {
+				if ($reader instanceof \logstore_legacy\log\store) {
+					$sql['legacy'] = "SELECT id, userid, time, course
+										FROM {log}
+										WHERE module = 'forum' AND action = 'view discussion'";
+				} else if ($reader instanceof \logstore_standard\log\store) {
+					$sql['standard'] = "SELECT id, userid, timecreated AS time, courseid AS course
+										FROM {logstore_standard_log}
+										WHERE target = 'discussion' AND action = 'viewed'";
+				}
+			}
+			$query_sql = 'SELECT c.id, c.userid FROM (' . implode(' UNION ', $sql) . ') c WHERE c.course = :courseid AND c.time >= :startdate AND c.time <= :enddate';
+			// read logs
+			$logs = $DB->get_recordset_sql($query_sql, $params);
+		}
+        if ($readposts) {
             foreach ($readposts as $read) {
                 if (!isset($posts[$read->userid])) {
                     $posts[$read->userid]['read'] = 0;
@@ -136,7 +161,21 @@ class indicator_forum extends indicator {
                 $risks[$userid] = $info;
                 continue;
             }
-
+			
+			// Add missing data if necessary.
+			if (empty($this->rawdata->posts[$userid]['total'])) {
+				$this->rawdata->posts[$userid]['total'] = 0;
+			}   
+			if (empty($this->rawdata->posts[$userid]['replies'])) {
+				$this->rawdata->posts[$userid]['replies'] = 0;
+			}   
+			if (empty($this->rawdata->posts[$userid]['new'])) {
+				$this->rawdata->posts[$userid]['new'] = 0;
+			}   
+			if (empty($this->rawdata->posts[$userid]['read'])) {
+				$this->rawdata->posts[$userid]['read'] = 0;
+			}   
+			
             $local_risk = $this->calculate('totalposts', $this->rawdata->posts[$userid]['total']);
             $risk_contribution = $local_risk * $this->config['w_totalposts'];
             $reason = new stdClass();

--- a/indicator/indicator.class.php
+++ b/indicator/indicator.class.php
@@ -30,6 +30,7 @@ abstract class indicator {
     protected $courseid;
     protected $instance;
     protected $rawdata;
+	protected $userarray;
 
     public function __construct($courseid, array $_config = array()) {
         global $DB;
@@ -107,10 +108,19 @@ abstract class indicator {
             }
         }
         $users = array_keys($users);
+		$this->userarray = $users;
 
         return self::get_risk_for_users($users, $startdate, $enddate);
     }
 
+	public function get_course_rawdata($startdate = null, $enddate = null) {
+		return $this->rawdata;
+	}
+	
+	public function get_course_users() {
+		return $this->userarray;
+	}	
+	
     private function get_risk_for_users($userids, $startdate, $enddate) {
         global $DB, $CFG;
 

--- a/indicator/indicator.class.php
+++ b/indicator/indicator.class.php
@@ -112,7 +112,7 @@ abstract class indicator {
     }
 
     private function get_risk_for_users($userids, $startdate, $enddate) {
-        global $DB;
+        global $DB, $CFG;
 
         if (empty($userids)) {
             return array();
@@ -120,11 +120,22 @@ abstract class indicator {
             $userids = array($userids);
         }
 
+		require_once($CFG->dirroot . '/report/engagement/locallib.php');
+		$generic_settings = report_engagement_get_generic_settings($this->courseid);
+		
         if ($startdate == null) {
-            $this->startdate = $DB->get_field('course', 'startdate', array('id' => $this->courseid));
+			if (isset($generic_settings['queryspecifydatetime']) && $generic_settings['queryspecifydatetime']->value && $generic_settings['querystartdatetime']->value) {
+				$this->startdate = $generic_settings['querystartdatetime']->value;
+			} else {
+				$this->startdate = $DB->get_field('course', 'startdate', array('id' => $this->courseid));
+			}
         }
         if ($enddate == null) {
-            $this->enddate = time();
+			if (isset($generic_settings['queryspecifydatetime']) && $generic_settings['queryspecifydatetime']->value && $generic_settings['queryenddatetime']->value) {
+				$this->enddate = $generic_settings['queryenddatetime']->value;
+			} else {
+				$this->enddate = time();
+			}
         }
 
         $this->cachettl = get_config('engagement', 'cachettl');

--- a/indicator/login/indicator.class.php
+++ b/indicator/login/indicator.class.php
@@ -41,15 +41,30 @@ class indicator_login extends indicator {
 
         $sessions = array();
 
-        $params = array();
-        $params['courseid'] = $this->courseid;
-        $params['startdate'] = $startdate;
-        $params['enddate'] = $enddate;
-        $sql = "SELECT id, userid, time
-                FROM {log}
-                WHERE course = :courseid AND time >= :startdate AND time <= :enddate
-                ORDER BY time ASC";
-        if ($logs = $DB->get_recordset_sql($sql, $params)) {
+		// set the sql based on log reader(s) available
+		$params = array();
+		$params['courseid_legacy'] = $params['courseid_standard'] = $this->courseid;
+		$params['startdate_legacy'] = $params['startdate_standard'] = $startdate;
+		$params['enddate_legacy'] = $params['enddate_standard'] = $enddate;
+		$sql = array();
+		$logmanager = get_log_manager();
+		$readers = $logmanager->get_readers(); 
+		foreach ($readers as $reader) {
+			if ($reader instanceof \logstore_legacy\log\store) {
+				$sql['legacy'] = 'SELECT id, userid, time
+									FROM {log}
+									WHERE course = :courseid_legacy AND time >= :startdate_legacy AND time <= :enddate_legacy';
+			} else if ($reader instanceof \logstore_standard\log\store) {
+				$sql['standard'] = 'SELECT id, userid, timecreated AS time
+									FROM {logstore_standard_log}
+									WHERE courseid = :courseid_standard AND timecreated >= :startdate_standard AND timecreated <= :enddate_standard';
+			}
+		}
+		$query_sql = 'SELECT c.id, c.userid, c.time FROM (' . implode(' UNION ', $sql) . ') c ORDER BY time ASC';
+		// read logs
+		$logs = $DB->get_recordset_sql($query_sql, $params);
+				
+        if ($logs) {
             // Need to calculate sessions, sessions are defined by time between consequtive logs not exceeding setting.
             foreach ($logs as $log) {
                 $increment = false;

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$module->version   = 2014042902;       // The current plugin version (Date: YYYYMMDDXX)
+$module->version   = 2015052102;       // The current plugin version (Date: YYYYMMDDXX)
 $module->requires  = 2013101800;      // Requires this Moodle version
 $module->component = 'mod_engagement'; // Full name of the plugin (used for diagnostics).
 $module->dependencies = array('report_engagement' => 2015052101);

--- a/version.php
+++ b/version.php
@@ -27,5 +27,6 @@ defined('MOODLE_INTERNAL') || die;
 $module->version   = 2014042902;       // The current plugin version (Date: YYYYMMDDXX)
 $module->requires  = 2013101800;      // Requires this Moodle version
 $module->component = 'mod_engagement'; // Full name of the plugin (used for diagnostics).
+$module->dependencies = array('report_engagement' => 2015052101);
 
 $module->maturity = MATURITY_STABLE;


### PR DESCRIPTION
For the assessment indicator: Currently if there is e.g. mod_assign with nosubmissions = 1, the get_rawdata method adds grademax of each grade item to sumgrades. However, sometimes assignments are made with no submissions allowed, and these are brought into the risk calculation even though students cannot submit, meaning the max indicator risk is less than 100%.

Commit 65cb77f addresses this issue. Commit 1c34e45 is a minor UI change that shows one decimal place in the risk renderer, instead of no decimal places. This is to make more sense of the risk calculation when e.g. lots of 0.8% risk contributions add up but the renderer displays it as 0% risk, misleadingly.